### PR TITLE
Fix FamilyGroupRename Endpoint

### DIFF
--- a/FamilyVaultServer/Controllers/FamilyGroupController.cs
+++ b/FamilyVaultServer/Controllers/FamilyGroupController.cs
@@ -1,5 +1,4 @@
-﻿using FamilyVaultServer.Models;
-using FamilyVaultServer.Models.Requests;
+﻿using FamilyVaultServer.Models.Requests;
 using FamilyVaultServer.Models.Responses;
 using FamilyVaultServer.Services.PrivMx;
 using FamilyVaultServer.Utils;
@@ -72,7 +71,7 @@ namespace FamilyVaultServer.Controllers
         {
             try
             {
-                var response = await _privMx.UpdateContext(request.ContextId, request.Name, null, null, null);
+                var response = await _privMx.UpdateContext(request.ContextId, request.Name);
 
                 return Ok();
             }

--- a/FamilyVaultServer/Services/PrivMx/IPrivMxService.cs
+++ b/FamilyVaultServer/Services/PrivMx/IPrivMxService.cs
@@ -9,7 +9,7 @@ namespace FamilyVaultServer.Services.PrivMx
         Task<PrivMxCreateContextResult> CreateContext(string name, string description, string scope);
         Task<bool> AddUserToContext(string contextId, string userId, string userPubKey, string acl);
         Task<PrivMxListUsersFromContextResult> PrivMxListUsersFromContext(string contextId, int skip, int limit, string sortOrder);
-        Task<bool> UpdateContext(string contextId, string? name, string? description, string? scope, string? policy);
+        Task<bool> UpdateContext(string contextId, string? name = null, string? description = null, string? scope = null, string? policy = null);
         Task<bool> SetUserAcl(string contextId, string userId, string acl);
     }
 }

--- a/FamilyVaultServer/Services/PrivMx/PrivMxBridgeClient.cs
+++ b/FamilyVaultServer/Services/PrivMx/PrivMxBridgeClient.cs
@@ -3,6 +3,7 @@ using FamilyVaultServer.Services.PrivMx.Models.Params;
 using FamilyVaultServer.Services.PrivMx.Models.Result;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace FamilyVaultServer.Services.PrivMx
 {
@@ -53,11 +54,15 @@ namespace FamilyVaultServer.Services.PrivMx
             return response.Result;
         }
 
-
         private async Task<Stream> SendRequestAndGetResponseStream<TRequestParameters>(PrivMxRequest<TRequestParameters> request)
             where TRequestParameters : PrivMxRequestParameters
         {
-            var response = await _httpClient.PostAsJsonAsync("api", request);
+            var jsonSerializerOptions = new JsonSerializerOptions
+            {
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            };
+
+            var response = await _httpClient.PostAsJsonAsync("api", request, jsonSerializerOptions);
 
             if (!response.IsSuccessStatusCode)
             {


### PR DESCRIPTION
Nie możemy dopasować endpointa do dokumentacji i przekazywać nulli, wtedy parametry się nie zgadzają i mamy error. Jeśli nie chcemy przekazywać jakichś parametrów, to musimy je usunąć, a nie przekazywać nulla.